### PR TITLE
Add ability to kill a ongoing job from the web-ui

### DIFF
--- a/examples/OddJobsCliExample.lhs
+++ b/examples/OddJobsCliExample.lhs
@@ -75,7 +75,7 @@ myJobRunner job = do
       putStrLn $ "This should call the function that actually sends the welcome email. " <>
         "\nWe are purposely waiting 60 seconds before completing this job so that graceful shutdown can be demonstrated."
       delaySeconds (Seconds 60)
-      putStrLn "60 second wait is now over..."
+      putStrLn $ "SendWelcomeEmail to user: " <> (show userId) <> " complete (60 second wait is now over...)"
     SendPasswordResetEmail tkn ->
       putStrLn "This should call the function that actually sends the password-reset email"
     SetupSampleData userId -> do
@@ -109,7 +109,7 @@ main = do
           -- `OddJobs.ConfigBuilder`. If you want to actually use
           -- structured-logging you'll need to define your own logging function.
           let jobLogger = defaultTimedLogger logger (defaultLogStr defaultJobType)
-              cfg = mkConfig jobLogger "jobs" dbPool (MaxConcurrentJobs 50) myJobRunner Prelude.id
+              cfg = mkConfig jobLogger "jobs_test" dbPool (MaxConcurrentJobs 50) myJobRunner Prelude.id
 
           -- Finally, executing the callback function that was passed to me...
           callback cfg

--- a/package.yaml
+++ b/package.yaml
@@ -83,6 +83,7 @@ dependencies:
   - servant-server
   - servant-lucid
   - warp
+  - containers
   - unordered-containers
   - optparse-applicative
   - direct-daemonize
@@ -148,4 +149,3 @@ tests:
       - mmorph
       - lifted-base
       - lifted-async
-      - containers

--- a/src/OddJobs/ConfigBuilder.hs
+++ b/src/OddJobs/ConfigBuilder.hs
@@ -102,6 +102,10 @@ defaultLogStr jobTypeFn logLevel logEvent =
       LogJobTimeout j@Job{jobLockedAt, jobLockedBy} ->
         "Timeout | " <> jobToLogStr j <> " | lockedBy=" <> (toLogStr $ maybe  "unknown" unJobRunnerName jobLockedBy) <>
         " lockedAt=" <> (toLogStr $ maybe "unknown" show jobLockedAt)
+      LogKillJobSuccess j ->
+        "Kill Job Success | " <> (jobToLogStr j)
+      LogKillJobFailed j ->
+        "Kill Job Failed | " <> (jobToLogStr j) <> "(the job might have completed or timed out)"
       LogPoll ->
         "Polling jobs table"
       LogWebUIRequest ->
@@ -278,6 +282,12 @@ defaultJsonLogEvent logEvent =
                    , "contents" Aeson..= (defaultJsonJob job, show e, defaultJsonFailureMode fm, runTime) ]
     LogJobTimeout job ->
       Aeson.object [ "tag" Aeson..= ("LogJobTimeout" :: Text)
+                   , "contents" Aeson..= (defaultJsonJob job) ]
+    LogKillJobSuccess job ->
+      Aeson.object [ "tag" Aeson..= ("LogKillJobSuccess" :: Text)
+                   , "contents" Aeson..= (defaultJsonJob job) ]
+    LogKillJobFailed job ->
+      Aeson.object [ "tag" Aeson..= ("LogKillJobFailed" :: Text)
                    , "contents" Aeson..= (defaultJsonJob job) ]
     LogPoll ->
       Aeson.object [ "tag" Aeson..= ("LogJobPoll" :: Text)]

--- a/src/OddJobs/Job.hs
+++ b/src/OddJobs/Job.hs
@@ -450,10 +450,9 @@ killJob jid = do
 
     (Just job, Nothing) -> do
       log LevelInfo $ LogKillJobFailed job
-      return ()
 
     (Nothing, _) ->
-      error $ "Unable to find job in db to kill, jobId = " <> (show jid)
+      log LevelError $ LogText $ "Unable to find job in db to kill, jobId = " <> toS (show jid)
 
 -- TODO: This might have a resource leak.
 restartUponCrash :: (HasJobRunner m, Show a) => Text -> m a -> m ()

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -21,7 +21,9 @@ createJobTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
   ", attempts int not null default 0" <>
   ", locked_at timestamp with time zone null" <>
   ", locked_by text null" <>
-  ", constraint incorrect_locking_info CHECK ((status <> 'locked' and locked_at is null and locked_by is null) or (status = 'locked' and locked_at is not null and locked_by is not null))" <>
+  ", constraint incorrect_locking_info CHECK (" <>
+    "(locked_at is null and locked_by is null and status <> 'locked') or " <>
+    "(locked_at is not null and locked_by is not null and (status = 'locked' or status = 'cancelled')))" <>
   ");" <>
   "create index if not exists ? on ?(created_at);" <>
   "create index if not exists ? on ?(updated_at);" <>

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -72,6 +72,11 @@ data LogEvent
   | LogJobFailed !Job !SomeException !FailureMode !NominalDiffTime
   -- | Emitted when a job times out and is picked-up again for execution
   | LogJobTimeout !Job
+  -- | Emitted when user kills a job and the job thread sucessfully cancelled thereafter.
+  | LogKillJobSuccess !Job
+  -- | Emitted when user kills a job and the job thread is not found in the threadRef
+  -- | (most likely the job has either got completed or timed out).
+  | LogKillJobFailed !Job 
   -- | Emitted whenever 'OddJobs.Job.jobPoller' polls the DB table
   | LogPoll
   -- | TODO

--- a/src/OddJobs/Types.hs
+++ b/src/OddJobs/Types.hs
@@ -154,8 +154,11 @@ data Status
   -- | Jobs in 'Queued' status /may/ be picked up by the job-runner on the basis
   -- of the 'jobRunAt' field.
   | Queued
-  -- | Jobs in 'Failed' status will will not be retried by the job-runner.
+  -- | Jobs in 'Failed' status will not be retried by the job-runner.
   | Failed
+  -- | Jobs with 'Cancelled' status are cancelled by the user and will not be 
+  -- retried by the job-runner
+  | Cancelled
   -- | Jobs in 'Retry' status will be retried by the job-runner on the basis of
   -- the 'jobRunAt' field.
   | Retry
@@ -199,6 +202,7 @@ instance ToText Status where
     Queued -> "queued"
     Retry -> "retry"
     Failed -> "failed"
+    Cancelled -> "cancelled"
     Locked -> "locked"
 
 instance (StringConv Text a) => FromText (Either a Status) where
@@ -206,6 +210,7 @@ instance (StringConv Text a) => FromText (Either a Status) where
     "success" -> Right Success
     "queued" -> Right Queued
     "failed" -> Right Failed
+    "cancelled" -> Right Cancelled
     "retry" -> Right Retry
     "locked" -> Right Locked
     x -> Left $ toS $ "Unknown job status: " <> x

--- a/src/OddJobs/Web.hs
+++ b/src/OddJobs/Web.hs
@@ -379,6 +379,7 @@ jobRow routes t (job@Job{..}, jobHtml) = do
       let statusFn = case jobStatus of
             Job.Success -> statusSuccess
             Job.Failed -> statusFailed
+            Job.Cancelled -> statusCancelled
             Job.Queued -> if jobRunAt > t
                           then statusFuture
                           else statusWaiting
@@ -391,6 +392,7 @@ jobRow routes t (job@Job{..}, jobHtml) = do
       let actionsFn = case jobStatus of
             Job.Success -> (const mempty)
             Job.Failed -> actionsFailed
+            Job.Cancelled -> (const mempty)
             Job.Queued -> if jobRunAt > t
                           then actionsFuture
                           else actionsWaiting
@@ -437,6 +439,12 @@ statusFailed t Job{..} = do
   span_ [ class_ "badge badge-danger" ] $ "Failed"
   span_ [ class_ "job-run-time" ] $ do
     abbr_ [ title_ (showText jobUpdatedAt) ] $ toHtml $ "Failed " <> humanReadableTime' t jobUpdatedAt <> " after " <> show jobAttempts <> " attempts"
+
+statusCancelled :: UTCTime -> Job -> Html ()
+statusCancelled t Job{..} = do
+  span_ [ class_ "badge badge-danger" ] $ "Killed"
+  span_ [ class_ "job-run-time" ] $ do
+    abbr_ [ title_ (showText jobUpdatedAt) ] $ toHtml $ "Cancelled " <> humanReadableTime' t jobUpdatedAt
 
 statusFuture :: UTCTime -> Job -> Html ()
 statusFuture t Job{..} = do

--- a/src/OddJobs/Web.hs
+++ b/src/OddJobs/Web.hs
@@ -120,6 +120,7 @@ data Routes = Routes
   , rEnqueue :: JobId -> Text
   , rRunNow :: JobId -> Text
   , rCancel :: JobId -> Text
+  , rKill :: JobId -> Text
   , rRefreshJobTypes :: Text
   , rRefreshJobRunners :: Text
   , rStaticAsset :: Text -> Text
@@ -394,7 +395,7 @@ jobRow routes t (job@Job{..}, jobHtml) = do
                           then actionsFuture
                           else actionsWaiting
             Job.Retry -> actionsRetry
-            Job.Locked -> (const mempty)
+            Job.Locked -> actionsKill
       actionsFn routes job
 
 
@@ -417,6 +418,11 @@ actionsWaiting :: Routes -> Job -> Html ()
 actionsWaiting Routes{..} Job{..} = do
   form_ [ action_ (rCancel jobId), method_ "post" ] $ do
     button_ [ class_ "btn btn-danger", type_ "submit" ] $ "Cancel"
+
+actionsKill :: Routes -> Job -> Html ()
+actionsKill Routes{..} Job{..} = do
+  form_ [ action_ (rKill jobId), method_ "post" ] $ do
+    button_ [ class_ "btn btn-danger", type_ "submit" ] $ "Kill"
 
 statusSuccess :: UTCTime -> Job -> Html ()
 statusSuccess t Job{..} = do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -192,6 +192,9 @@ assertJobIdStatus conn tname logRef msg st jid = do
                                           Job.LogJobFailed j _ _ _ -> jid == Job.jobId j
                                           _ -> False
 
+    Job.Cancelled ->
+      assertBool "this is a dummy message" $ 1 == 1
+
     Job.Retry ->
       assertBool (msg <> ": Failed event not found in job-logs for JobId=" <> show jid) $
       (flip DL.any) logs $ \logEvent -> case logEvent of


### PR DESCRIPTION
__Changes introduced in this PR__
- Type of `envJobThreadsRef` is changed to a Map from a List
- A new status `Cancelled` is added, This is used to represent a job that is cancelled by the user via Admin UI
- A new thread `killJobPoller` is forked along with `JobPoller` and `jobEventListener`. This polls for jobs that are cancelled by the user and are Started / locked by a JobRunner (refer `killJobPollingSqlM`) and kills them.
- Some UI / UX improvements

 When a user cancels a job (Locked/Queued), its status is changed to `cancelled`. If this job is already locked by a JobRunner, it's respective `killJobPoller` will pick it up and kill the job thread.
  

__Breaking change__: Constraint on jobs table needs to be updated, to account for the new `cancelled` status 
```
BEGIN;
ALTER TABLE jobs DROP CONSTRAINT incorrect_locking_info;
ALTER TABLE jobs ADD CONSTRAINT incorrect_locking_info CHECK(
  (locked_at is null and locked_by is null and status <> 'locked') or
  (locked_at is not null and locked_by is not null and (status = 'locked' or status = 'cancelled'))
);
COMMIT;
```

https://user-images.githubusercontent.com/18610982/128295246-b8e6b0df-84c8-4e15-b470-a5d2581baeb3.mov

TODO: Improve / add test cases that cover all possible user flows. Right now the test cases rely heavily on timing and delays, This causes some of them to fail every now and then (happened couple of times to me on master branch).