### PR TITLE
Add resource-based concurrency control

### DIFF
--- a/odd-jobs.cabal
+++ b/odd-jobs.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 6677b61240c930d793f07c90cd9dc719586179d99bdc7dc7b3dbe9a32d9a2afa
 
 name:           odd-jobs
 version:        0.2.2
@@ -61,7 +59,14 @@ library
       Paths_odd_jobs
   hs-source-dirs:
       src
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns
   build-depends:
       aeson
@@ -116,12 +121,20 @@ executable devel
   hs-source-dirs:
       dev
       src
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns -threaded -with-rtsopts=-N -main-is DevelMain
   build-depends:
       aeson
     , base >=4.7 && <5
     , bytestring
+    , containers
     , direct-daemonize
     , directory
     , either
@@ -163,12 +176,20 @@ executable odd-jobs-cli-example
       Paths_odd_jobs
   hs-source-dirs:
       examples
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns -threaded -with-rtsopts=-N -main-is OddJobsCliExample
   build-depends:
       aeson
     , base >=4.7 && <5
     , bytestring
+    , containers
     , direct-daemonize
     , directory
     , either
@@ -220,7 +241,14 @@ test-suite jobrunner
   hs-source-dirs:
       test
       src
-  default-extensions: NamedFieldPuns LambdaCase TemplateHaskell ScopedTypeVariables GeneralizedNewtypeDeriving QuasiQuotes OverloadedStrings
+  default-extensions:
+      NamedFieldPuns
+      LambdaCase
+      TemplateHaskell
+      ScopedTypeVariables
+      GeneralizedNewtypeDeriving
+      QuasiQuotes
+      OverloadedStrings
   ghc-options: -Wall -fno-warn-orphans -fno-warn-unused-imports -fno-warn-dodgy-exports -Werror=missing-fields -Werror=incomplete-patterns -threaded -with-rtsopts=-N -main-is Test
   build-depends:
       aeson

--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 module OddJobs.Migrations
   ( module OddJobs.Migrations
   , module OddJobs.Types
@@ -70,4 +71,60 @@ createJobTable conn tname = void $ do
   where
     fnName = PGS.Identifier $ "notify_job_monitor_for_" <> (getTnameTxt tname)
     trgName = PGS.Identifier $ "trg_notify_job_monitor_for_" <> (getTnameTxt tname)
+    getTnameTxt (PGS.QualifiedIdentifier _ tname') = tname'
+
+createResourceTableQuery :: Query
+createResourceTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
+  "( id text primary key" <>
+  ", usage_limit int not null" <>
+  ")";
+
+createUsageTableQuery :: Query
+createUsageTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
+  "( job_id serial not null REFERENCES ? ON DELETE CASCADE" <>
+  ", resource_id text not null REFERENCES ? ON DELETE CASCADE" <>
+  ", usage int not null" <>
+  ", PRIMARY KEY (job_id, resource_id)" <>
+  ");"
+
+createUsageFunction :: Query
+createUsageFunction = "CREATE OR REPLACE FUNCTION ?(resourceId text) RETURNS int as $$" <>
+  " SELECT sum(usage) FROM ? AS j INNER JOIN ? AS jr ON j.id = jr.job_id " <>
+  " WHERE jr.resource_id = $1 AND j.status = ? " <>
+  " $$ LANGUAGE SQL;"
+
+createCheckResourceFunction :: Query
+createCheckResourceFunction = "CREATE OR REPLACE FUNCTION ?(jobId int) RETURNS bool as $$" <>
+  " SELECT coalesce(bool_and(?(resource.id) + job_resource.usage <= resource.usage_limit), true) FROM " <>
+  " ? AS job_resource INNER JOIN ? AS resource ON job_resource.resource_id = resource.id " <>
+  " WHERE job_resource.job_id = $1" <>
+  " $$ LANGUAGE SQL;"
+
+createResourceTables
+  :: Connection
+  -> TableName -- ^ Name of the jobs table
+  -> ResourceCfg
+  -> IO ()
+createResourceTables conn jobTableName ResourceCfg{..} = void $ do
+  PGS.execute conn createResourceTableQuery (PGS.Only resCfgResourceTable)
+  PGS.execute conn createUsageTableQuery
+    ( resCfgUsageTable
+    , jobTableName
+    , resCfgResourceTable
+    )
+  let
+  PGS.execute conn createUsageFunction
+    ( usageFnName
+    , jobTableName
+    , resCfgUsageTable
+    , Locked
+    )
+  PGS.execute conn createCheckResourceFunction
+    ( resCfgCheckResourceFunction
+    , usageFnName
+    , resCfgUsageTable
+    , resCfgResourceTable
+    )
+  where
+    usageFnName = PGS.Identifier $ "calculate_usage_for_resource_from_" <> (getTnameTxt resCfgUsageTable)
     getTnameTxt (PGS.QualifiedIdentifier _ tname') = tname'


### PR DESCRIPTION
This is based on the system in saurabhnanda/odd-jobs#55, and aims to
address saurabhnanda/odd-jobs#38, where jobs need to have some limited
access to resources that controls how many can run simultaneously.

Unlike that PR, this implements a system where jobs can require access
to 0 or more resources, with different amounts of usage. This is because
of a business need for jobs to be able to require multiple resources.

The implementation is intended to have no performance impact on existing
code wherever the user has not opted in to resource-based concurrency.
This is done by having parallel implementations wherever necessary that
switch based on the concurrency control chosen.

This subsumes and replaces the job-type-based concurrency control,
because it is possible to model that system using job types as
resources.