### PR TITLE
Fix resource checking when no jobs are locked

### DIFF
--- a/src/OddJobs/Migrations.hs
+++ b/src/OddJobs/Migrations.hs
@@ -89,7 +89,7 @@ createUsageTableQuery = "CREATE TABLE IF NOT EXISTS ?" <>
 
 createUsageFunction :: Query
 createUsageFunction = "CREATE OR REPLACE FUNCTION ?(resourceId text) RETURNS int as $$" <>
-  " SELECT sum(usage) FROM ? AS j INNER JOIN ? AS jr ON j.id = jr.job_id " <>
+  " SELECT coalesce(sum(usage), 0) FROM ? AS j INNER JOIN ? AS jr ON j.id = jr.job_id " <>
   " WHERE jr.resource_id = $1 AND j.status = ? " <>
   " $$ LANGUAGE SQL;"
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -229,13 +229,13 @@ withRandomTable jobPool action = do
     ((Pool.withResource jobPool $ \conn -> (liftIO $ Migrations.createJobTable conn tname)) >> (action tname))
     (Pool.withResource jobPool $ \conn -> liftIO $ void $ PGS.execute conn "drop table if exists ?" (Only tname))
 
--- withRandomResourceTables :: (MonadIO m) => Pool Connection -> Job.TableName -> (Job.ResourceCfg -> m a) -> m a
-withRandomResourceTables jobPool tname action = do
+-- withRandomResourceTables :: (MonadIO m) => Int -> Pool Connection -> Job.TableName -> (Job.ResourceCfg -> m a) -> m a
+withRandomResourceTables defaultLimit jobPool tname action = do
   resCfgResourceTable <- liftIO ((fromString . ("resources_" <>)) <$> (replicateM 10 (R.randomRIO ('a', 'z'))))
   resCfgUsageTable <- liftIO ((fromString . ("usage_" <>)) <$> (replicateM 10 (R.randomRIO ('a', 'z'))))
   resCfgCheckResourceFunction <- liftIO ((fromString . ("check_resource_fn_" <>)) <$> (replicateM 10 (R.randomRIO ('a', 'z'))))
   let resCfg = Job.ResourceCfg
-        { Job.resCfgDefaultLimit = 1
+        { Job.resCfgDefaultLimit = defaultLimit
         , ..
         }
 
@@ -470,11 +470,40 @@ testResourceLimitedScheduling appPool jobPool = testGroup "concurrency control b
       assertJobIdStatus conn tname logRef "First job should have succeeded by now" Job.Success firstJob
       assertJobIdStatus conn tname logRef "Second job should be running after first job suceeded" Job.Locked secondJob
       assertJobIdStatus conn tname logRef "Third job fits alongside second job - it should be running after first job suceeded" Job.Locked thirdJob
+
+  , testCase "resource limits permanently block too-big jobs" $ setup $ \tname resCfg logRef conn -> do
+      let firstResource = [(Job.ResourceId "first", 2)]
+
+      Job{jobId = firstJob} <- Job.createJobWithResources conn tname resCfg (PayloadSucceed 10) firstResource
+
+      delaySeconds $ Job.defaultPollingInterval + Seconds 2
+
+      assertJobIdStatus conn tname logRef "Job requires too many resources - shouldn't be running" Job.Queued firstJob
+
+  , testCase "resources with 0 limit block jobs" $ setup' 0 $ \tname resCfg logRef conn -> do
+      let firstResource = [(Job.ResourceId "first", 1)]
+
+      Job{jobId = firstJob} <- Job.createJobWithResources conn tname resCfg (PayloadSucceed 10) firstResource
+
+      delaySeconds $ Job.defaultPollingInterval + Seconds 2
+
+      assertJobIdStatus conn tname logRef "Job can't access 0-limited resources - shouldn't be running" Job.Queued firstJob
+
+  , testCase "resources with negative limit block jobs" $ setup' (-5) $ \tname resCfg logRef conn -> do
+      let firstResource = [(Job.ResourceId "first", 1)]
+
+      Job{jobId = firstJob} <- Job.createJobWithResources conn tname resCfg (PayloadSucceed 10) firstResource
+
+      delaySeconds $ Job.defaultPollingInterval + Seconds 2
+
+      assertJobIdStatus conn tname logRef "Job can't access negative-limited resources - shouldn't be running" Job.Queued firstJob
   ]
   where
-    setup action =
+    setup = setup' 1
+
+    setup' defaultLimit action =
       withRandomTable jobPool $ \tname ->
-        withRandomResourceTables jobPool tname $ \resCfg ->
+        withRandomResourceTables defaultLimit jobPool tname $ \resCfg ->
           withNamedJobMonitor tname jobPool (cfgFn resCfg) $ \logRef -> do
             Pool.withResource appPool $ \conn -> action tname resCfg logRef conn
 


### PR DESCRIPTION
The job runner would always queue up the first job to try and use a resource, since there was a `NULL` sneaking into the calculation of how much the resource was already being used. This fixes that bug, and adds some tests that the new function logic is correct.