### PR TITLE
Visually collapse large job payloads in UI

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -42,7 +42,6 @@ td.job-type {
 
 .job .job-payload {
     color: #777;
-    display: inline-block;
 }
 
 .job-payload .key {
@@ -142,11 +141,19 @@ abbr[title] {
     margin-right: 0.75rem;
 }
 
+.job .job-payload.collapsed {
+    height: 1.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: break-spaces;
+    color: #777;
+}
+
 .job .job-error.collapsed {
     height: 1.5em;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: no-wrap;
+    white-space: break-spaces;
     color: #777;
 }
 

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,3 +1,11 @@
+function togglePayload(e) {
+  var $e = $(e).closest('.job-payload');
+  $e.toggleClass('expanded').toggleClass('collapsed');
+  $e.find('.badge.payload-expand').toggleClass('d-none');
+  $e.find('.badge.payload-collapse').toggleClass('d-none');
+  return false;
+}
+
 function toggleError(e) {
   var $e = $(e).closest('.job-error');
   $e.toggleClass('expanded').toggleClass('collapsed');


### PR DESCRIPTION
Very large job payloads can clog up the UI because they are displayed completely everywhere they appear. This steals some code from job errors (which are always collapsed) to collapse "large" payloads and make the user expand them to view them instead.

![image](https://user-images.githubusercontent.com/74535922/153422852-aca5cf03-d1e4-4681-8570-38b7f82c5f6a.png)
